### PR TITLE
Drop tables and indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,19 @@ First, dump your MySQL database in PostgreSQL-compatible format
     mysqldump --compatible=postgresql --default-character-set=utf8 \
     -r databasename.mysql -u root gitlabhq_production -p
 
-Then, convert it using the dbconverter.py script and move the 'DROP INDEX' statements to the start.
+Then, convert it using the dbconverter.py script.
 
     python db_converter.py databasename.mysql databasename.psql
-    ed -s databasename.psql < move_drop_indexes.ed
 
 It'll print progress to the terminal
+
+Now we have a DB dump that can be imported but the dump will be slow due
+to existing indexes. We use 'ed' to edit the DB dump file and move the
+'DROP INDEX' statements to the start of the import. Ed is not the fastest
+tool for this job if your DB dump is multiple gigabytes. (Patches to
+the converter are welcome!)
+
+    ed -s databasename.psql < move_drop_indexes.ed
 
 Next, load your new dump into a fresh PostgreSQL database using: 
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ GitLab.
   6.8 because the GitLab database schema contains no binary columns.
 - Never set 'NOT NULL' constraints on datetimes.
 - Drop sequences before creating them.
-- Import all indexes.
-- Import index names.
 - Preserve default values of boolean (originally `tinyint(1)`) columns.
 - Import all indexes.
 - Import index names.
+- Drop tables before creating.
+- Drop indexes before creating.
 
 How to use
 ----------
@@ -33,9 +33,10 @@ First, dump your MySQL database in PostgreSQL-compatible format
     mysqldump --compatible=postgresql --default-character-set=utf8 \
     -r databasename.mysql -u root gitlabhq_production -p
 
-Then, convert it using the dbconverter.py script
+Then, convert it using the dbconverter.py script and move the 'DROP INDEX' statements to the start.
 
-`python db_converter.py databasename.mysql databasename.psql`
+    python db_converter.py databasename.mysql databasename.psql
+    ed -s databasename.psql < move_drop_indexes.ed
 
 It'll print progress to the terminal
 

--- a/db_converter.py
+++ b/db_converter.py
@@ -29,6 +29,7 @@ def parse(input_filename, output_filename):
     enum_types = []
     foreign_key_lines = []
     index_lines = []
+    drop_index_lines = []
     sequence_lines = []
     cast_lines = []
     num_inserts = 0
@@ -185,6 +186,7 @@ def parse(input_filename, output_filename):
                 index_name      = line.split('"')[1].split('"')[0]
                 index_columns   = line.split("(")[1].split(")")[0]
                 index_lines.append("CREATE UNIQUE INDEX \"%s\" ON %s (%s)" % (index_name, current_table, index_columns))
+                drop_index_lines.append("DROP INDEX IF EXISTS \"%s\"" % index_name)
             elif line.startswith("UNIQUE KEY"):
                 index_columns   = line.split("(")[1].split(")")[0]
                 index_lines.append("CREATE UNIQUE INDEX ON %s (%s)" % (current_table, index_columns))
@@ -192,6 +194,7 @@ def parse(input_filename, output_filename):
                 index_name      = line.split('"')[1].split('"')[0]
                 index_columns   = line.split("(")[1].split(")")[0]
                 index_lines.append("CREATE INDEX \"%s\" ON %s (%s)" % (index_name, current_table, index_columns))
+                drop_index_lines.append("DROP INDEX IF EXISTS \"%s\"" % index_name)
             elif line.startswith("KEY"):
                 index_columns = line.split("(")[1].split(")")[0]
                 index_lines.append("CREATE INDEX ON %s (%s)" % (current_table, index_columns))
@@ -230,6 +233,13 @@ def parse(input_filename, output_filename):
     output.write("\n-- Sequences --\n")
     for line in sequence_lines:
         output.write("%s;\n" % line)
+
+    # This line is an anchor for move_drop_indexes.ed
+    output.write("\n-- Drop indexes --\n")
+    for line in drop_index_lines:
+        output.write("%s;\n" % line)
+    # This line is an anchor for move_drop_indexes.ed
+    output.write("-- END Drop indexes --\n")
 
     # Write indexes out
     output.write("\n-- Indexes --\n")

--- a/db_converter.py
+++ b/db_converter.py
@@ -200,6 +200,7 @@ def parse(input_filename, output_filename):
                 index_lines.append("CREATE INDEX ON %s USING gin(to_tsvector('english', %s))" % (current_table, fulltext_keys))
             # Is it the end of the table?
             elif line == ");":
+                output.write("DROP TABLE IF EXISTS \"%s\";\n" % current_table)
                 output.write("CREATE TABLE \"%s\" (\n" % current_table)
                 for i, line in enumerate(creation_lines):
                     output.write("    %s%s\n" % (line, "," if i != (len(creation_lines) - 1) else ""))

--- a/move_drop_indexes.ed
+++ b/move_drop_indexes.ed
@@ -1,0 +1,12 @@
+# Look for the 'Drop indexes' line and mark it with 'a'
+/^-- Drop indexes --$/
+ka
+# Look for the 'END Drop indexes' line and mark it with 'b'
+/^-- END Drop indexes --$/
+kb
+# Move the 'Drop indexes'..'END Drop indexes' block after the line containing
+# 'SET CONSTRAINTS'.
+1
+/SET CONSTRAINTS/
+'a,'bm.
+wq


### PR DESCRIPTION
Starting in GitLab 7.13, the GitLab backup restore script will no longer drop all tables and indexes at the start of a restore, so we need to do that with commands in the DB dump. This change adds those commands to the converted DB dump.
